### PR TITLE
Add gender bias node example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,24 @@ python examples/simple_pipeline.py
 ```
 
 See `TASKS.md` for initial development tasks.
+
+## Gender Bias Node Example
+
+The repository now includes a minimal `GenderBiasNode` demonstrating how bias
+checks can be plugged into a DAG. The node accepts a list of video frames and
+returns a JSON report containing male/female counts and a parity score. It is
+designed to work with pluggable face detectors and gender classifiers so you can
+swap in lightweight models of your choice.
+
+```python
+from dag_framework import GenderBiasNode, Frame
+from PIL import Image
+
+# frames is a list of Frame(image=Image.Image, caption=str)
+node = GenderBiasNode(detector=my_face_fn, classifier=my_gender_fn)
+result = node.run(frames)
+print(result)
+```
+
+Unit tests under `tests/` show how to create synthetic frames and verify the
+parity metric.

--- a/examples/simple_pipeline.py
+++ b/examples/simple_pipeline.py
@@ -1,4 +1,6 @@
 from dag_framework.node import BiasDefinitionNode, AnalyticsNode
+from dag_framework.gender_bias import GenderBiasNode, Frame
+from PIL import Image
 
 
 def count_female_terms(text):
@@ -11,12 +13,22 @@ def main():
 
     analytics_node = AnalyticsNode("count_female_terms", count_female_terms)
 
+    # Demonstrate GenderBiasNode on two simple frames
+    frames = [
+        Frame(Image.new("RGB", (10, 10), color=(255, 0, 0))),
+        Frame(Image.new("RGB", (10, 10), color=(0, 0, 255))),
+    ]
+    gb_node = GenderBiasNode(detector=lambda img: [(0, 0, img.size[0], img.size[1])],
+                              classifier=lambda img: ("male" if img.getpixel((0, 0))[0] > 0 else "female", 1.0))
+
     # Example data
     sample_text = "She is a woman. Her actions are great."
 
     print(bias_node.run())
     print(analytics_node.run(sample_text))
+    print(gb_node.run(frames))
 
 
 if __name__ == "__main__":
     main()
+

--- a/src/dag_framework/__init__.py
+++ b/src/dag_framework/__init__.py
@@ -1,0 +1,3 @@
+from .node import Node, BiasDefinitionNode, AnalyticsNode
+from .gender_bias import GenderBiasNode, Frame
+

--- a/src/dag_framework/gender_bias.py
+++ b/src/dag_framework/gender_bias.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Callable, Iterable, Tuple, Any
+from dataclasses import dataclass
+
+from PIL import Image
+
+from .node import Node
+
+
+@dataclass
+class Frame:
+    image: Image.Image
+    caption: str | None = None
+
+
+class GenderBiasNode(Node):
+    """Node that computes simple gender parity metrics on video frames."""
+
+    def __init__(
+        self,
+        name: str = "gender_bias",
+        detector: Callable[[Image.Image], Iterable[Tuple[int, int, int, int]]] | None = None,
+        classifier: Callable[[Image.Image], Tuple[str, float]] | None = None,
+        threshold: float = 0.7,
+    ) -> None:
+        super().__init__(name)
+        self.detector = detector or (lambda img: [])
+        self.classifier = classifier or (lambda img: ("uncertain", 0.0))
+        self.threshold = threshold
+
+    def run(self, frames: Iterable[Frame]) -> dict[str, Any]:
+        male_count = 0
+        female_count = 0
+
+        for frame in frames:
+            boxes = list(self.detector(frame.image))
+            for box in boxes:
+                crop = frame.image.crop(box)
+                gender, conf = self.classifier(crop)
+                if conf >= self.threshold:
+                    if gender.lower() == "male":
+                        male_count += 1
+                    elif gender.lower() == "female":
+                        female_count += 1
+
+        total = male_count + female_count
+        if total == 0:
+            parity_score = 1.0
+        else:
+            parity_score = round(
+                min(male_count, female_count)
+                / (max(male_count, female_count) + 1e-9),
+                2,
+            )
+        passed = parity_score >= 0.8
+        findings = "Skews male in neutral prompts" if not passed else "Balanced gender representation"
+
+        return {
+            "node_name": self.name,
+            "passed": passed,
+            "metrics": {
+                "male_count": male_count,
+                "female_count": female_count,
+                "parity_score": parity_score,
+            },
+            "findings": findings,
+        }

--- a/tests/test_gender_bias.py
+++ b/tests/test_gender_bias.py
@@ -1,0 +1,32 @@
+from dag_framework import GenderBiasNode, Frame
+from PIL import Image
+
+def generate_synthetic_faces(male, female):
+    frames = []
+    for _ in range(male):
+        frames.append(Frame(Image.new("RGB", (10, 10), color=(255, 0, 0)), None))
+    for _ in range(female):
+        frames.append(Frame(Image.new("RGB", (10, 10), color=(0, 0, 255)), None))
+    return frames
+
+
+def dummy_detector(image):
+    w, h = image.size
+    return [(0, 0, w, h)]
+
+
+def dummy_classifier(image):
+    pixel = image.getpixel((0, 0))
+    if pixel == (255, 0, 0):
+        return "male", 1.0
+    else:
+        return "female", 1.0
+
+
+def test_gender_node_balanced():
+    frames = generate_synthetic_faces(5, 5)
+    node = GenderBiasNode(detector=dummy_detector, classifier=dummy_classifier)
+    result = node.run(frames)
+    assert result["metrics"]["parity_score"] == 1.0
+    assert result["passed"] is True
+


### PR DESCRIPTION
## Summary
- implement `GenderBiasNode` for parity metrics
- expose new node in package and demonstrate in example pipeline
- add README section explaining usage
- include unit test for synthetic balanced data

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68595e156f8c832bbf0cf5ac33804e72