### PR TITLE
Implement video analytics helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,21 @@ print(result)
 
 Unit tests under `tests/` show how to create synthetic frames and verify the
 parity metric.
+
+## Video Analytics Pipeline Example
+
+A helper in `dag_framework.video_pipeline` runs any analytics nodes on a video
+file and stores the combined results in a directory acting as a bucket.
+
+```python
+from dag_framework import GenderBiasNode, run_video_analytics
+
+results = run_video_analytics(
+    "path/to/video.mp4",
+    [GenderBiasNode(detector=my_face, classifier=my_gender)],
+    "output_bucket",
+)
+```
+
+The function loads the video, executes each analytics node on the frames, and
+writes a `report.json` file with all findings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,10 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "dag-framework"
 version = "0.1.0"
+dependencies = [
+    "pillow",
+    "imageio",
+]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/dag_framework/__init__.py
+++ b/src/dag_framework/__init__.py
@@ -1,3 +1,4 @@
 from .node import Node, BiasDefinitionNode, AnalyticsNode
 from .gender_bias import GenderBiasNode, Frame
+from .video_pipeline import read_video_frames, run_video_analytics
 

--- a/src/dag_framework/video_pipeline.py
+++ b/src/dag_framework/video_pipeline.py
@@ -1,0 +1,48 @@
+import os
+import json
+from typing import Iterable, List
+
+import imageio.v2 as imageio
+from PIL import Image
+
+from .gender_bias import Frame
+from .node import Node, AnalyticsNode
+
+
+def read_video_frames(video_path: str) -> List[Frame]:
+    """Load video frames from ``video_path`` as ``Frame`` objects."""
+    reader = imageio.get_reader(video_path)
+    frames = [Frame(Image.fromarray(frame)) for frame in reader]
+    reader.close()
+    return frames
+
+
+def run_video_analytics(
+    video_path: str,
+    analytics_nodes: Iterable[AnalyticsNode],
+    bucket_dir: str | None = None,
+) -> dict[str, dict]:
+    """Run analytics nodes on the video and optionally store results.
+
+    Parameters
+    ----------
+    video_path:
+        Path to the video file to analyze.
+    analytics_nodes:
+        Iterable of ``AnalyticsNode`` instances.
+    bucket_dir:
+        Optional directory representing a storage bucket where results
+        will be written as ``report.json``.
+    """
+    frames = read_video_frames(video_path)
+    results: dict[str, dict] = {}
+    for node in analytics_nodes:
+        results[node.name] = node.run(frames)
+
+    if bucket_dir is not None:
+        os.makedirs(bucket_dir, exist_ok=True)
+        report_path = os.path.join(bucket_dir, "report.json")
+        with open(report_path, "w", encoding="utf-8") as fh:
+            json.dump(results, fh, indent=2)
+
+    return results

--- a/tests/test_video_pipeline.py
+++ b/tests/test_video_pipeline.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+from dag_framework import GenderBiasNode, run_video_analytics
+from PIL import Image
+
+
+def dummy_detector(image):
+    w, h = image.size
+    return [(0, 0, w, h)]
+
+
+def dummy_classifier(image):
+    pixel = image.getpixel((0, 0))
+    return ("male", 1.0) if pixel == (255, 0, 0) else ("female", 1.0)
+
+
+def create_sample_gif(path: Path):
+    frame1 = Image.new("RGB", (10, 10), color=(255, 0, 0))
+    frame2 = Image.new("RGB", (10, 10), color=(0, 0, 255))
+    frame1.save(path, save_all=True, append_images=[frame2], loop=0, duration=100)
+
+
+def test_run_video_analytics(tmp_path: Path):
+    video_path = tmp_path / "sample.gif"
+    create_sample_gif(video_path)
+
+    node = GenderBiasNode(detector=dummy_detector, classifier=dummy_classifier)
+    results = run_video_analytics(str(video_path), [node], tmp_path)
+
+    assert results[node.name]["metrics"]["male_count"] == 1
+    assert results[node.name]["metrics"]["female_count"] == 1
+    assert (tmp_path / "report.json").exists()


### PR DESCRIPTION
## Summary
- add video pipeline helper to run DAG analytics over a video
- expose helper functions in package __init__
- document usage in README
- declare dependencies
- test pipeline on a synthetic gif

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68596128facc832b856e12ca6d75507c