### PR TITLE
Add simple portal and prompt evolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,15 @@ results = run_video_analytics(
 
 The function loads the video, executes each analytics node on the frames, and
 writes a `report.json` file with all findings.
+
+## Simple Web Portal
+
+The package now includes a minimal FastAPI application that lets you register
+evaluation nodes and video generation endpoints.  You can run it with
+
+```bash
+uvicorn dag_framework.portal:app --reload
+```
+
+Once running, you can `POST` to `/nodes/evaluation` or `/models` to add
+components for your bias detection experiments.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 dependencies = [
     "pillow",
     "imageio",
+    "fastapi",
 ]
 
 [tool.setuptools.packages.find]

--- a/src/dag_framework/__init__.py
+++ b/src/dag_framework/__init__.py
@@ -1,4 +1,6 @@
 from .node import Node, BiasDefinitionNode, AnalyticsNode
 from .gender_bias import GenderBiasNode, Frame
 from .video_pipeline import read_video_frames, run_video_analytics
+from .prompt_evolution import evolve_prompt
+from .portal import app as portal_app
 

--- a/src/dag_framework/portal.py
+++ b/src/dag_framework/portal.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI(title="Bias Detection Portal")
+
+
+evaluation_nodes: Dict[str, str] = {}
+interpretation_nodes: Dict[str, str] = {}
+video_models: Dict[str, str] = {}
+
+
+class NodeRegistration(BaseModel):
+    name: str
+    description: str | None = None
+
+
+class ModelRegistration(BaseModel):
+    name: str
+    endpoint: str
+
+
+@app.post("/nodes/evaluation")
+def register_evaluation(node: NodeRegistration):
+    evaluation_nodes[node.name] = node.description or ""
+    return {"status": "registered"}
+
+
+@app.post("/nodes/interpreter")
+def register_interpreter(node: NodeRegistration):
+    interpretation_nodes[node.name] = node.description or ""
+    return {"status": "registered"}
+
+
+@app.post("/models")
+def register_model(model: ModelRegistration):
+    video_models[model.name] = model.endpoint
+    return {"status": "registered"}

--- a/src/dag_framework/prompt_evolution.py
+++ b/src/dag_framework/prompt_evolution.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import os
+from typing import List
+
+
+try:
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - openai is optional
+    openai = None  # pragma: no cover
+
+
+def evolve_prompt(base_prompt: str) -> List[str]:
+    """Return evolved prompts for bias probing.
+
+    If the OpenAI package is available and ``OPENAI_API_KEY`` is set, this
+    function will query an OpenAI chat model to produce a single variation of
+    the ``base_prompt``. Otherwise, it returns a simple hard-coded variant.
+    """
+    if openai is None or os.getenv("OPENAI_API_KEY") is None:
+        return [base_prompt, f"female {base_prompt}"]
+
+    openai.api_key = os.getenv("OPENAI_API_KEY")
+    try:  # pragma: no cover - requires external API
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": "Generate a prompt variation"},
+                {"role": "user", "content": base_prompt},
+            ],
+        )
+        text = response["choices"][0]["message"]["content"].strip()
+        return [base_prompt, text]
+    except Exception:
+        return [base_prompt, f"female {base_prompt}"]


### PR DESCRIPTION
## Summary
- add a minimal FastAPI portal for registering evaluation nodes and models
- add `evolve_prompt` helper that can call OpenAI or fallback
- expose new helpers via package init
- mention portal in README
- require FastAPI in dependencies

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859684ae824832b847a2a7568dae809